### PR TITLE
Use collect and Result::is_ok for unix path additions

### DIFF
--- a/lib/system/env/unix.rs
+++ b/lib/system/env/unix.rs
@@ -33,7 +33,7 @@ pub async fn add_to_path(home: &Home) -> RokitResult<bool> {
 
     // Add the path to known shell profiles
     let added_any = if let Some(home_dir) = dirs::home_dir() {
-        let futs = Shell::ALL
+        Shell::ALL
             .iter()
             .map(|shell| {
                 let shell_env_path = home_dir.join(shell.env_file_path());
@@ -44,8 +44,11 @@ pub async fn add_to_path(home: &Home) -> RokitResult<bool> {
                     shell_should_create,
                 )
             })
-            .collect::<FuturesUnordered<_>>();
-        futs.collect::<Vec<_>>().await.iter().any(Result::is_ok)
+            .collect::<FuturesUnordered<_>>()
+            .collect::<Vec<_>>()
+            .await
+            .iter()
+            .any(Result::is_ok)
     } else {
         false
     };


### PR DESCRIPTION
This PR closes #1 by using `collect` and `Result::is_ok` to prevent Unix path additions from failing if some shell configuration files are unable to be found. 