### PR TITLE
Use stderr for tracing output

### DIFF
--- a/src/util/tracing.rs
+++ b/src/util/tracing.rs
@@ -1,3 +1,5 @@
+use std::io::stderr;
+
 use tracing::level_filters::LevelFilter;
 use tracing_subscriber::EnvFilter;
 
@@ -26,11 +28,13 @@ pub fn init() {
     if FMT_PRETTY {
         tracing_subscriber::fmt()
             .with_env_filter(tracing_env_filter)
+            .with_writer(stderr)
             .pretty()
             .init();
     } else {
         tracing_subscriber::fmt()
             .with_env_filter(tracing_env_filter)
+            .with_writer(stderr)
             .with_target(false)
             .without_time()
             .init();


### PR DESCRIPTION
Rokit currently uses stdout for tracing output - this includes error messages such as when Rokit fails to run a tool.

This PR sets the tracing subscriber to use stderr, under the assumption that it is only used for warnings and hard errors, not regular output. Searching for the `info!` macro shows no matches so this should hold true.

Fixes #17