### PR TITLE
Fix permissions bug with self-update on windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- `rokit self-update` will no longer encounter an OS error on Windows systems
+
 ## `0.1.3` - June 18th, 2024
 
 ### Changed

--- a/lib/storage/tool_storage.rs
+++ b/lib/storage/tool_storage.rs
@@ -208,7 +208,14 @@ impl ToolStorage {
             // with the OS killing the current executable when its overwritten.
             if rokit_link_existed {
                 let temp_file = tempfile::tempfile()?;
-                let temp_path = temp_file.path()?;
+                let mut temp_path = temp_file.path()?;
+                #[cfg(windows)]
+                {
+                    // Windows raises an OS error if the current binary is
+                    // renamed to a file name without a .exe extension. So to
+                    // avoid that, we add the extension.
+                    temp_path.set_extension("exe");
+                }
                 trace!(
                     ?temp_path,
                     "moving existing Rokit binary to temporary location"


### PR DESCRIPTION
For reasons known only to Microsoft, binaries have a moment when they're renamed to something other than a .exe while they're running. This results in a permissions error every time on Windows when running `rokit self-update`.

The fix to this is simple and it's just to set the extension of the temporary file to `.exe` on Windows.