### PR TITLE
Fix failing to parse tool specifications in foreman.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Failed to parse tool specifications in foreman.toml if they were an inline table
+- Failed to parse tool specifications in foreman.toml if they were an inline table ([#36])
+
+[#36]: https://github.com/rojo-rbx/rokit/pull/36
 
 ## `0.1.4` - July 11th, 2024
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Failed to parse tool specifications in foreman.toml if they were an inline table
+
 ## `0.1.4` - July 11th, 2024
 
 ### Fixed

--- a/lib/discovery/foreman.rs
+++ b/lib/discovery/foreman.rs
@@ -1,11 +1,16 @@
 use std::{collections::HashMap, str::FromStr};
 
 use semver::Version;
-use toml_edit::DocumentMut;
+use toml_edit::{DocumentMut, InlineTable, Table};
 
 use crate::tool::{ToolAlias, ToolId, ToolSpec};
 
 use super::Manifest;
+
+enum SpecType {
+    InlineTable(InlineTable),
+    Table(Table),
+}
 
 #[derive(Debug, Clone)]
 pub(crate) struct ForemanManifest {
@@ -35,9 +40,19 @@ impl Manifest for ForemanManifest {
         if let Some(map) = self.document.get("tools").and_then(|t| t.as_table()) {
             for (alias, tool_def) in map {
                 let tool_alias = alias.parse::<ToolAlias>().ok();
-                let tool_spec = tool_def
-                    .as_inline_table()
-                    .and_then(parse_foreman_tool_definition);
+
+                let tool_spec = if tool_def.is_inline_table() {
+                    tool_def
+                        .as_inline_table()
+                        .cloned()
+                        .and_then(|map| parse_foreman_tool_definition(SpecType::InlineTable(map)))
+                } else {
+                    tool_def
+                        .as_table()
+                        .cloned()
+                        .and_then(|map| parse_foreman_tool_definition(SpecType::Table(map)))
+                };
+
                 if let (Some(alias), Some(spec)) = (tool_alias, tool_spec) {
                     tools.insert(alias, spec);
                 }
@@ -47,7 +62,12 @@ impl Manifest for ForemanManifest {
     }
 }
 
-fn parse_foreman_tool_definition(map: &toml_edit::InlineTable) -> Option<ToolSpec> {
+fn parse_foreman_tool_definition(map: SpecType) -> Option<ToolSpec> {
+    let map = match map {
+        SpecType::InlineTable(table) => table,
+        SpecType::Table(table) => table.into_inline_table(),
+    };
+
     let version = map.get("version").and_then(|t| t.as_str()).and_then(|v| {
         // TODO: Support real version requirements instead of just exact/min versions
         let without_prefix = v.trim_start_matches('=').trim_start_matches('^');

--- a/lib/discovery/foreman.rs
+++ b/lib/discovery/foreman.rs
@@ -35,7 +35,9 @@ impl Manifest for ForemanManifest {
         if let Some(map) = self.document.get("tools").and_then(|t| t.as_table()) {
             for (alias, tool_def) in map {
                 let tool_alias = alias.parse::<ToolAlias>().ok();
-                let tool_spec = tool_def.as_table().and_then(parse_foreman_tool_definition);
+                let tool_spec = tool_def
+                    .as_inline_table()
+                    .and_then(parse_foreman_tool_definition);
                 if let (Some(alias), Some(spec)) = (tool_alias, tool_spec) {
                     tools.insert(alias, spec);
                 }
@@ -45,7 +47,7 @@ impl Manifest for ForemanManifest {
     }
 }
 
-fn parse_foreman_tool_definition(map: &toml_edit::Table) -> Option<ToolSpec> {
+fn parse_foreman_tool_definition(map: &toml_edit::InlineTable) -> Option<ToolSpec> {
     let version = map.get("version").and_then(|t| t.as_str()).and_then(|v| {
         // TODO: Support real version requirements instead of just exact/min versions
         let without_prefix = v.trim_start_matches('=').trim_start_matches('^');


### PR DESCRIPTION
Resolves #35 

It does actually locate the foreman.toml, it just failed to parse the tool specification if it was an inline table. We were trying to parse it as a regular toml table, when really foreman supports both regular and inline tables.