### PR TITLE
Improve artifact compatibility by adding a fallback mechanism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Failed to parse tool specifications in foreman.toml if they were an inline table ([#36])
+- Fixed tool specifications failing to parse in `foreman.toml` when using inline tables ([#36])
+- Fixed tools not specifying architectures (such as `wally-macos.zip`) failing to install ([#38])
 
 [#36]: https://github.com/rojo-rbx/rokit/pull/36
+[#38]: https://github.com/rojo-rbx/rokit/pull/38
 
 ## `0.1.4` - July 11th, 2024
 

--- a/lib/sources/artifact.rs
+++ b/lib/sources/artifact.rs
@@ -245,4 +245,38 @@ impl Artifact {
             .map(|(_, artifact)| artifact.clone())
             .collect()
     }
+
+    /**
+        Tries to find a partially compatible artifact, to be used as a fallback
+        during artifact selection if [`Artifact::sort_by_system_compatibility`]
+        finds no system-compatible artifacts to use.
+
+        Returns `None` if more than one artifact is partially compatible.
+    */
+    pub fn find_partially_compatible_fallback(artifacts: impl AsRef<[Self]>) -> Option<Self> {
+        let current_desc = Descriptor::current_system();
+
+        let os_compatible_artifacts = artifacts
+            .as_ref()
+            .iter()
+            .filter_map(|artifact| {
+                let name = artifact.name.as_deref()?;
+                if let Some(asset_desc) = Descriptor::detect(name) {
+                    if current_desc.os() == asset_desc.os() {
+                        Some(artifact)
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>();
+
+        if os_compatible_artifacts.len() == 1 {
+            Some(os_compatible_artifacts[0].clone())
+        } else {
+            None
+        }
+    }
 }

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -5,9 +5,9 @@ use clap::Parser;
 
 use console::style;
 use futures::{stream::FuturesUnordered, TryStreamExt};
-use rokit::{discovery::discover_all_manifests, sources::Artifact, storage::Home};
+use rokit::{discovery::discover_all_manifests, storage::Home};
 
-use crate::util::{prompt_for_trust_specs, CliProgressTracker};
+use crate::util::{find_most_compatible_artifact, prompt_for_trust_specs, CliProgressTracker};
 
 /// Adds a new tool using Rokit and installs it.
 #[derive(Debug, Parser)]
@@ -84,10 +84,7 @@ impl InstallSubcommand {
                 let artifacts = source.get_specific_release(&tool_spec).await?;
                 pt.subtask_completed();
 
-                let artifact = Artifact::sort_by_system_compatibility(&artifacts)
-                    .first()
-                    .cloned()
-                    .with_context(|| format!("No compatible artifact found for {tool_spec}"))?;
+                let artifact = find_most_compatible_artifact(&artifacts, tool_spec.id())?;
                 pt.subtask_completed();
 
                 let contents = source

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -3,9 +3,9 @@ use clap::Parser;
 use console::style;
 use semver::Version;
 
-use rokit::{sources::Artifact, storage::Home, tool::ToolId};
+use rokit::{storage::Home, tool::ToolId};
 
-use crate::util::CliProgressTracker;
+use crate::util::{find_most_compatible_artifact, CliProgressTracker};
 
 /// Updates Rokit to the latest version.
 #[derive(Debug, Parser)]
@@ -55,9 +55,7 @@ impl SelfUpdateSubcommand {
         pt.task_completed();
         pt.update_message("Downloading");
 
-        let artifact = Artifact::sort_by_system_compatibility(&artifacts)
-            .first()
-            .cloned()
+        let artifact = find_most_compatible_artifact(&artifacts, &tool_id)
             .context("No compatible Rokit artifact was found (WAT???)")?;
         let artifact_contents = source
             .download_artifact_contents(&artifact)

--- a/src/runner/info.rs
+++ b/src/runner/info.rs
@@ -20,7 +20,7 @@ fn is_likely_rosetta2_error(e: &Error) -> bool {
 
     let is_running_macos_aarch64 = {
         let current = Descriptor::current_system();
-        matches!(current.os(), OS::MacOS) && matches!(current.arch(), Arch::Arm64)
+        matches!(current.os(), OS::MacOS) && matches!(current.arch(), Some(Arch::Arm64))
     };
 
     is_bad_cpu_type && is_running_macos_aarch64

--- a/src/util/artifacts.rs
+++ b/src/util/artifacts.rs
@@ -1,0 +1,73 @@
+use anyhow::{Context, Result};
+
+use rokit::{
+    descriptor::Descriptor,
+    sources::{Artifact, ArtifactProvider},
+    tool::ToolId,
+};
+
+pub fn find_most_compatible_artifact(artifacts: &[Artifact], tool_id: &ToolId) -> Result<Artifact> {
+    let mut artifact_opt = Artifact::sort_by_system_compatibility(artifacts)
+        .first()
+        .cloned();
+
+    if artifact_opt.is_none() {
+        let current_desc = Descriptor::current_system();
+
+        // If we failed to find an artifact compatible with the current system,
+        // we may be able to give additional information to Rokit's users, or tool
+        // maintainers who want to be Rokit-compatible, by examining the artifacts
+        let no_artifacts_with_arch = artifacts.iter().all(|artifact| {
+            artifact
+                .name
+                .as_deref()
+                .and_then(Descriptor::detect)
+                .map_or(false, |desc| desc.arch().is_none())
+        });
+        let additional_information = if no_artifacts_with_arch {
+            let source_is_github = artifacts
+                .iter()
+                .all(|artifact| matches!(artifact.provider, ArtifactProvider::GitHub));
+            let source_name = if source_is_github {
+                "GitHub release files"
+            } else {
+                "tool release files"
+            };
+            Some(format!(
+                "This seems to have been caused by {0} not \
+                specifying an architecture in any of its artifacts.\
+                \nIf you are the maintainer of this tool, you can resolve \
+                this issue by specifying an architecture in {source_name}:\
+                \n    {0}-{1}-{2}.zip",
+                tool_id.name(),
+                current_desc.os().as_str(),
+                current_desc.arch().expect("no current arch (??)").as_str(),
+            ))
+        } else {
+            None
+        };
+
+        // Let the user know about failing to find an artifact,
+        // potentially with additional information generated above
+        tracing::warn!(
+            "Failed to find a fully compatible artifact for {tool_id}!{}\
+            \nSearching for a fallback...",
+            match additional_information {
+                Some(info) => format!("\n{info}"),
+                None => String::new(),
+            }
+        );
+
+        if let Some(artifact) = Artifact::find_partially_compatible_fallback(artifacts) {
+            tracing::info!(
+                "Found fallback artifact '{}' for tool {tool_id}",
+                artifact.name.as_deref().unwrap_or("N/A")
+            );
+            artifact_opt.replace(artifact);
+        }
+    }
+
+    // If we did not find a compatible artifact, either directly
+    // or through a fallback mechanism, this should be a hard error
+    artifact_opt.with_context(|| format!("No compatible artifact found for {tool_id}"))
+}

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,4 +1,5 @@
 mod alias_or_id_or_spec;
+mod artifacts;
 mod constants;
 mod id_or_spec;
 mod progress;
@@ -6,6 +7,7 @@ mod prompts;
 mod tracing;
 
 pub use self::alias_or_id_or_spec::ToolAliasOrIdOrSpec;
+pub use self::artifacts::find_most_compatible_artifact;
 pub use self::id_or_spec::ToolIdOrSpec;
 pub use self::progress::CliProgressTracker;
 pub use self::prompts::{prompt_for_trust, prompt_for_trust_specs};


### PR DESCRIPTION
This PR implements a simple fallback mechanism for when tools do not specify architectures in their release files:
- `tool-name-windows.zip`
- `other-tool_macos.tar.gz`
- etc

`Arch` is no longer mandatory in a `Descriptor` since this seems to be a common pattern, and Rokit should not assume any architecture as "default" since arm macs and pcs are now much more common. We will implement improved fallbacks in the future as part of #4, but for now this PR solves a very real issue and does so in a user-friendly way while also spreading awareness.

Fixes #37

