### PR TITLE
Fix artifact matching being sensitive to extensions, add tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed artifacts with names such as `toolname-win64.zip` not being detected as compatible on Windows ([#39])
+
+[#39]: https://github.com/rojo-rbx/rokit/pull/39
+
+## `0.1.5` - July 14th, 2024
+
+### Fixed
+
 - Fixed tool specifications failing to parse in `foreman.toml` when using inline tables ([#36])
 - Fixed tools not specifying architectures (such as `wally-macos.zip`) failing to install ([#38])
 

--- a/lib/util/path.rs
+++ b/lib/util/path.rs
@@ -3,6 +3,35 @@
 use std::path::{Path, PathBuf};
 
 /**
+    Splits a filename into its base name and a list of extensions.
+
+    This is useful for handling files with multiple extensions, such as `file-name.ext1.ext2`.
+
+    # Example
+
+    ```rust ignore
+    let (name, exts) = split_filename_and_extensions("file-name.ext1.ext2");
+    assert_eq!(name, "file-name");
+    assert_eq!(exts, vec!["ext1", "ext2"]);
+    ```
+*/
+pub(crate) fn split_filename_and_extensions(name: &str) -> (&str, Vec<&str>) {
+    let mut path = Path::new(name);
+    let mut exts = Vec::new();
+
+    // Reverse-pop extensions off the path until we reach the
+    // base name - we will then need to reverse afterwards, too
+    while let Some(ext) = path.extension() {
+        exts.push(ext.to_str().expect("input was str"));
+        path = Path::new(path.file_stem().expect("had an extension"));
+    }
+    exts.reverse();
+
+    let path = path.to_str().expect("input was str");
+    (path, exts)
+}
+
+/**
     Cleans up a path and simplifies it for writing to storage or environment variables.
 
     This will currently:


### PR DESCRIPTION
In version `0.1.2` of Rokit, more specifically commit https://github.com/rojo-rbx/rokit/commit/f7f928f3990eae88653c17065f887e65701fb230, Rokit started using a more strict OS and architecture detection algorithm. This passed all tests, but unfortunately, our tests did not catch a fatal flaw: OS and architecture detection was now sensitive to file extensions being included in the search string. Artifact names such as these:

- `toolname-win.zip`
- `toolname-win64.zip`

no longer downloaded correctly because `win.zip` was being interpreted as one "word" and this word was not in the list of words matching the Windows platform. This PR fixes the issue by stripping file extensions before parsing, and also adds extra tests to the `ArtifactFormat` enum and its parsing since it underwent some larger changes.