### PR TITLE
Fix tool cache loading erroring on first startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Fixed Rokit erroring on first startup due to some directories not yet being created
+
 ## `0.1.7` - July 15th, 2024
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed Rokit erroring on first startup due to some directories not yet being created
+- Fixed Rokit erroring on first startup due to some directories not yet being created ([#42])
+
+[#42]: https://github.com/rojo-rbx/rokit/pull/42
 
 ## `0.1.7` - July 15th, 2024
 

--- a/lib/storage/home.rs
+++ b/lib/storage/home.rs
@@ -2,6 +2,8 @@ use std::env::var;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+use tokio::fs::create_dir_all;
+
 use crate::manifests::AuthManifest;
 use crate::result::{RokitError, RokitResult};
 use crate::sources::ArtifactSource;
@@ -60,6 +62,7 @@ impl Home {
             let path = dirs::home_dir()
                 .ok_or(RokitError::HomeNotFound)?
                 .join(".rokit");
+            create_dir_all(&path).await?;
             Self::load_from_path(path).await
         }
     }


### PR DESCRIPTION
This PR fixes Rokit erroring the first time it starts by ensuring that all directories are pre-created and that the tool cache gets created properly if it does not already exist.