### PR TITLE
Fix an improperly handled `FileNotFound` error on initial `self-install`

### DIFF
--- a/lib/storage/tool_storage.rs
+++ b/lib/storage/tool_storage.rs
@@ -248,10 +248,10 @@ impl ToolStorage {
         let aliases_dir = home_path.join("bin").into();
 
         tokio::try_join!(
-            RokitManifest::load_or_create(&home_path),
-            AuthManifest::load_or_create(&home_path),
             async { Ok(create_dir_all(&tools_dir).await?) },
             async { Ok(create_dir_all(&aliases_dir).await?) },
+            RokitManifest::load_or_create(&home_path),
+            AuthManifest::load_or_create(&home_path),
         )?;
 
         let current_rokit_contents = Arc::new(AsyncMutex::new(None));


### PR DESCRIPTION
On the first Rokit run with self-install, it tries to create the `.rokit` directory in the user's home, using `create_dir_all` (which creates the tool storage directories and their parent, `.rokit`).

The underlying issue was that Rokit first tried to load or create the manifest files, which fail, since the parent directory does not exist.

This has been fixed by reordering `try_join!` call - we now create the directories first, and then the manifests, and since the directory creations are operations blocking with `await`; `try_join!` runs tasks concurrently, essentially waiting for the directory creations to finish first.