### PR TITLE
Implement automatic Rokit installation when launching from Windows Explorer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1929,6 +1929,7 @@ dependencies = [
  "unindent",
  "url",
  "which",
+ "winapi",
  "winreg",
  "zip",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,7 @@ tracing-subscriber = { optional = true, version = "0.3", features = [
 ] }
 
 [target.'cfg(windows)'.dependencies]
+winapi = { version = "0.3", features = ["wincon"] }
 winreg = "0.52"
 
 [lints.clippy]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,7 +91,7 @@ tracing-subscriber = { optional = true, version = "0.3", features = [
 ] }
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3", features = ["wincon"] }
+winapi = { version = "0.3", features = ["processthreadsapi", "wincon"] }
 winreg = "0.52"
 
 [lints.clippy]

--- a/README.md
+++ b/README.md
@@ -20,15 +20,17 @@ Follow the instructions for your platform below - when installed, Rokit will gui
 
 ### macOS & Linux
 
-- Run the automated installer script in your terminal:
+Run the automated installer script in your terminal:
 
-  ```sh
-  curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/rojo-rbx/rokit/main/scripts/install.sh | sh
-  ```
+```sh
+curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/rojo-rbx/rokit/main/scripts/install.sh | sh
+```
 
 ### Windows
 
-- Download and run `rokit.exe` from the [latest release][latest-release] page - this will automatically install Rokit.
+Download and run<sup>\*</sup> `rokit.exe` from the [latest release][latest-release] page - this will automatically install Rokit.
+
+<sup>\* Make sure to run `rokit.exe` **directly**, not from a shell such as PowerShell or CMD, for automatic installation to work.</sup>
 
 ### Other
 
@@ -37,7 +39,8 @@ Follow the instructions for your platform below - when installed, Rokit will gui
 Rokit can be compiled and installed from source using [`cargo`][rustup]:
 
 ```sh
-cargo install rokit --locked
+cargo install rokit --locked # Installs the Rokit binary
+rokit self-install # Initializes necessary directories and data files for Rokit to work
 ```
 
 This _may_ work on systems that Rokit is not officially compatible with, but note that no support is provided for non-official targets. <br/>

--- a/README.md
+++ b/README.md
@@ -28,8 +28,7 @@ Follow the instructions for your platform below - when installed, Rokit will gui
 
 ### Windows
 
-1. Download and unzip `rokit.exe` from the [latest release][latest-release] page.
-2. Open a terminal, change directory to where you downloaded Rokit, and run `./rokit.exe self-install`.
+- Download and run `rokit.exe` from the [latest release][latest-release] page - this will automatically install Rokit.
 
 ### Other
 

--- a/lib/system/mod.rs
+++ b/lib/system/mod.rs
@@ -1,7 +1,9 @@
 mod current;
 mod env;
+mod process;
 mod runner;
 
 pub use self::current::{current_dir, current_exe, current_exe_contents, current_exe_name};
 pub use self::env::{add_to_path, exists_in_path};
+pub use self::process::{Launcher as ProcessLauncher, Parent as ProcessParent};
 pub use self::runner::run_interruptible;

--- a/lib/system/process/mod.rs
+++ b/lib/system/process/mod.rs
@@ -1,0 +1,75 @@
+#![allow(clippy::unused_async)]
+
+use std::io::{stderr, stdout, IsTerminal};
+
+#[cfg(unix)]
+mod unix;
+
+#[cfg(windows)]
+mod windows;
+
+#[cfg(unix)]
+use self::unix as platform;
+
+#[cfg(windows)]
+use self::windows as platform;
+
+/**
+    Enum representing possible sources that may have launched Rokit.
+
+    Note that this in non-exhaustive, and may be extended in the future.
+*/
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum Launcher {
+    WindowsExplorer,
+    MacOsFinder,
+}
+
+/**
+    Enum representing the detected kind of parent process of Rokit.
+
+    Note that this in non-exhaustive, and may be extended in the future.
+*/
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum Parent {
+    Launcher(Launcher),
+    Terminal,
+}
+
+impl Parent {
+    /**
+        Returns `true` if the parent is a launcher.
+    */
+    #[must_use]
+    pub const fn is_launcher(self) -> bool {
+        matches!(self, Self::Launcher(_))
+    }
+
+    /**
+        Returns `true` if the parent is a terminal.
+    */
+    #[must_use]
+    pub const fn is_terminal(self) -> bool {
+        matches!(self, Self::Terminal)
+    }
+
+    /**
+        Tries to detect the parent process of Rokit.
+
+        Returns `None` if the parent process could not be detected.
+    */
+    pub async fn get() -> Option<Self> {
+        platform::try_detect_launcher()
+            .await
+            .map(Self::Launcher)
+            .or_else(|| {
+                if stdout().is_terminal() || stderr().is_terminal() {
+                    Some(Self::Terminal)
+                } else {
+                    None
+                }
+            })
+    }
+}

--- a/lib/system/process/unix.rs
+++ b/lib/system/process/unix.rs
@@ -1,0 +1,4 @@
+pub async fn try_detect_launcher() -> Option<super::Launcher> {
+    // FUTURE: Try to detect if this process was launched from Finder / Linux equivalent
+    None
+}

--- a/lib/system/process/windows.rs
+++ b/lib/system/process/windows.rs
@@ -1,0 +1,36 @@
+use winapi::um::processthreadsapi::GetCurrentProcessId;
+use winapi::um::wincon::GetConsoleProcessList;
+
+use super::Launcher;
+
+pub async fn try_detect_launcher() -> Option<super::Launcher> {
+    tracing::debug!("trying to detect launcher using Windows API");
+
+    /*
+        Allocate a buffer for process IDs - we need space for at
+        least one ID, which will hopefully be our own process ID
+    */
+    let mut process_list = [0u32; 1];
+    let process_id = unsafe { GetCurrentProcessId() };
+    let process_count = unsafe { GetConsoleProcessList(process_list.as_mut_ptr(), 1) };
+
+    tracing::debug!(
+        id = %process_id,
+        count = %process_count,
+        "got process id and count"
+    );
+
+    /*
+        If there's only one process (our process), the console will be destroyed on exit,
+        this very likely means it was launched from Explorer or a similar environment.
+
+        A similar environment could be the download folder in a web browser,
+        launching the program directly using the "Run" dialog, ..., but for
+        simplicity we'll just assume it was launched from Explorer.
+    */
+    if process_count == 1 && process_list[0] == process_id {
+        Some(Launcher::WindowsExplorer)
+    } else {
+        None
+    }
+}


### PR DESCRIPTION
This PR implements a mechanism for automatically installing Rokit when launched by double clicking the program in the Windows Explorer and similar locations (browser downloads list, etc).

This simplifies the first time user experience with Rokit for users that are not yet very familiar with using a terminal, since they no longer need to navigate to where they downloaded Rokit and run a subcommand first thing they do. It's also a nice convenience feature for experienced users.

The implementation is inspired by this official Windows developer blog post:
https://devblogs.microsoft.com/oldnewthing/20160125-00/?p=92922

Note that this implementation also leaves room for implementing a similar mechanism on macOS / Linux, however I have not yet found a consistent way to do this that does not also affect normal terminal usage of Rokit.