### PR TITLE
Add support for `--check` flag in update command

### DIFF
--- a/src/cli/update.rs
+++ b/src/cli/update.rs
@@ -260,6 +260,8 @@ impl UpdateSubcommand {
             ));
         }
 
+        // FUTURE: Install the newly updated tools automatically
+
         Ok(())
     }
 }

--- a/src/cli/update.rs
+++ b/src/cli/update.rs
@@ -18,7 +18,7 @@ pub struct UpdateSubcommand {
     /// Update tools globally instead of using the nearest manifest file.
     #[clap(long)]
     pub global: bool,
-
+    /// Check for updates without actually updating the tools.
     #[clap(long)]
     pub check: bool,
 }
@@ -153,7 +153,68 @@ impl UpdateSubcommand {
             .try_collect::<Vec<_>>()
             .await?;
 
-        // 4. Check if the --check flag was used, and is so, check for updates
+        // 4. Check if the --check flag was used, and if so, check for updates
+        let tools_changed = tool_releases
+            .iter()
+            .filter_map(|(alias, _, artifact)| {
+                let spec_old = manifest.get_tool(alias).unwrap();
+                let spec_new = artifact.tool_spec.clone();
+                if spec_old == spec_new {
+                    None
+                } else {
+                    Some((alias.clone(), spec_old, spec_new))
+                }
+            })
+            .collect::<Vec<_>>();
+        if self.check {
+            let bullet = style("•").dim();
+            let arrow = style("→").dim();
+
+            let updated_tool_lines = tools_changed
+                .iter()
+                .map(|(alias, spec_old, spec_new)| {
+                    format!(
+                        "{bullet} {} {} {arrow} {}",
+                        style(alias.to_string()).bold().cyan(),
+                        style(spec_old.version()).yellow(),
+                        style(spec_new.version()).bold().yellow()
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join("\n");
+
+            pt.update_message("Checking for updates");
+
+            if tools_changed.is_empty() {
+                pt.finish_with_message(format!(
+                    "All tools are already up-to-date! {}",
+                    pt.formatted_elapsed(),
+                ));
+            } else {
+                pt.finish_with_message(format!(
+                    "New versions are available for {} tool{} {}\
+                     \n\n{updated_tool_lines}\n\n\
+                    Run `{}` to update the tools.",
+                    style(tools_changed.len()).bold().magenta(),
+                    if tools_changed.len() == 1 { "" } else { "s" },
+                    pt.formatted_elapsed(),
+                    style("rokit update").bold().green(),
+                ));
+            }
+            pt.subtask_completed();
+            return Ok(());
+        }
+
+        // 5. Modify the manifest with the desired new tools, save
+        pt.update_message("Modifying");
+
+        for (alias, _, spec_new) in &tools_changed {
+            manifest.update_tool(alias, spec_new);
+            pt.subtask_completed();
+        }
+        manifest.save(&manifest_path).await?;
+
+        // 6. Finally, display a nice message to the user
         let tools_changed = tool_releases
             .iter()
             .filter_map(|(alias, _, artifact)| {
@@ -181,56 +242,23 @@ impl UpdateSubcommand {
             })
             .collect::<Vec<_>>()
             .join("\n");
-        if self.check {
-            pt.update_message("Checking for updates");
 
-            if tools_changed.is_empty() {
-                pt.finish_with_message(format!(
-                    "All tools are already up-to-date! {}",
-                    pt.formatted_elapsed(),
-                ));
-            } else {
-                pt.finish_with_message(format!(
-                    "New versions are available for {} tool{} {}\
-                     \n\n{updated_tool_lines}\n\n\
-                    Run `{}` to update the tools.",
-                    style(tools_changed.len()).bold().magenta(),
-                    if tools_changed.len() == 1 { "" } else { "s" },
-                    pt.formatted_elapsed(),
-                    style("rokit update").bold().green(),
-                ));
-            }
-            pt.subtask_completed();
+        if tools_changed.is_empty() {
+            pt.finish_with_message(format!(
+                "All tools are already up-to-date! {}",
+                pt.formatted_elapsed(),
+            ));
         } else {
-            // 5. Modify the manifest with the desired new tools, save
-            pt.update_message("Modifying");
-
-            for (alias, _, spec_new) in &tools_changed {
-                manifest.update_tool(alias, spec_new);
-                pt.subtask_completed();
-            }
-            manifest.save(&manifest_path).await?;
-
-            // 6. Finally, display a nice message to the user
-            if tools_changed.is_empty() {
-                pt.finish_with_message(format!(
-                    "All tools are already up-to-date! {}",
-                    pt.formatted_elapsed(),
-                ));
-            } else {
-                pt.finish_with_message(format!(
-                    "Updated versions for {} tool{} {}\
+            pt.finish_with_message(format!(
+                "Updated versions for {} tool{} {}\
                 \n\n{updated_tool_lines}\n\n\
                 Run `{}` to install the updated tools.",
-                    style(tools_changed.len()).bold().magenta(),
-                    if tools_changed.len() == 1 { "" } else { "s" },
-                    pt.formatted_elapsed(),
-                    style("rokit install").bold().green(),
-                ));
-            }
+                style(tools_changed.len()).bold().magenta(),
+                if tools_changed.len() == 1 { "" } else { "s" },
+                pt.formatted_elapsed(),
+                style("rokit install").bold().green(),
+            ));
         }
-
-        // FUTURE: Install the newly updated tools automatically
 
         Ok(())
     }


### PR DESCRIPTION
Closes: #47 

Implements support for a `--check` flag in the update command to check if there are any updates for installed tools but will not update the tools in question

Test used:
1. Make a random folder
2. Run `rokit init`
3. Change version of package(s) to an outdated version
3.1 Used Rojo version 7.4.1 to check for updates (expected to resolve version 7.4.2)
3.2 Used wally version 0.3.1 to check for updates (expected to resolve version 0.3.2)

Test resolved both of the correct up to date versions :)

_I'm new to rust so any feedback is appreciated!_ 🙃