### PR TITLE
Fix cross-device link error when running `self-update` on Linux

### DIFF
--- a/lib/storage/tool_storage.rs
+++ b/lib/storage/tool_storage.rs
@@ -203,7 +203,7 @@ impl ToolStorage {
         let was_rokit_updated = if existing_rokit_binary == rokit_contents {
             false
         } else {
-            if cfg!(unix) && rokit_link_existed {
+            if cfg!(target_os = "linux") && rokit_link_existed {
                 // On Linux, it's safe to remove the running binary.
                 // Moving to a temporary file can cause an error on some Linux systems
                 // due to /tmp being located on a different partition.

--- a/lib/storage/tool_storage.rs
+++ b/lib/storage/tool_storage.rs
@@ -203,10 +203,16 @@ impl ToolStorage {
         let was_rokit_updated = if existing_rokit_binary == rokit_contents {
             false
         } else {
-            // NOTE: If the currently running Rokit binary is being updated,
-            // we need to move it to a temporary location first to avoid issues
-            // with the OS killing the current executable when its overwritten.
-            if rokit_link_existed {
+            if cfg!(unix) && rokit_link_existed {
+                // On Linux, it's safe to remove the running binary.
+                // Moving to a temporary file can cause an error on some Linux systems
+                // due to /tmp being located on a different partition.
+                trace!(?rokit_path, "removing existing Rokit binary");
+                remove_file(&rokit_path).await?;
+            } else if rokit_link_existed {
+                // NOTE: If the currently running Rokit binary is being updated,
+                // we need to move it to a temporary location first to avoid issues
+                // with the OS killing the current executable when its overwritten.
                 let temp_file = tempfile::tempfile()?;
                 #[allow(unused_mut)]
                 let mut temp_path = temp_file.path()?;


### PR DESCRIPTION
`/tmp` is often located on a different partition than `/home` on Linux systems, causing an error when moving the existing binary to a temporary file.

This change removes the existing Rokit binary on Linux systems. This is safe to do as the binary will be unlinked after the process ends, but is still removed from the directory structure, allowing a new file with the same path to be written to.

Closes #57