### PR TITLE
Remove usage of command-group on unix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,6 @@ zip = "2.1"
 
 async-once-cell = "0.5"
 async-signal = "0.2"
-command-group = { version = "5.0", features = ["with-tokio"] }
 futures = "0.3"
 reqwest = { version = "0.12", default-features = false, features = [
     "rustls-tls",
@@ -91,6 +90,7 @@ tracing-subscriber = { optional = true, version = "0.3", features = [
 ] }
 
 [target.'cfg(windows)'.dependencies]
+command-group = { version = "5.0", features = ["with-tokio"] }
 winapi = { version = "0.3", features = ["processthreadsapi", "wincon"] }
 winreg = "0.52"
 


### PR DESCRIPTION
This PR drops all usage of the `command-group` crate and its wrappers on unix systems. Its main use case in Rokit is to prevent zombie processes on Windows, which is not necessary on other platforms, where we already handle all relevant shutdown signals.

The child process wrapper in `command-group` also has its own implementations of `spawn` and `kill` with hidden behavior on unix, such as spawning the child process inside of its own blocking task and I/O options - leading to problems like #61.

Fixes #61.