### PR TITLE
Fix incorrect executable suffix matching when finding best candidate for extraction

### DIFF
--- a/lib/sources/extraction.rs
+++ b/lib/sources/extraction.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::struct_excessive_bools)]
 
 use std::{
-    env::consts::EXE_SUFFIX,
+    env::consts::{EXE_EXTENSION, EXE_SUFFIX},
     io::{self, Read},
     path::{Path, PathBuf, MAIN_SEPARATOR_STR},
 };
@@ -96,7 +96,7 @@ impl Candidate {
                     file_name.is_some_and(|name| name.eq_ignore_ascii_case(desired_file_name));
 
                 let has_exec_perms = perms.map_or(false, |perms| (perms & 0o111) != 0);
-                let has_exec_suffix = path.extension().map_or(false, |ext| ext == EXE_SUFFIX);
+                let has_exec_suffix = path.extension().map_or(false, |ext| ext == EXE_EXTENSION);
 
                 Some(Self {
                     path: path.clone(),


### PR DESCRIPTION
This issue was breaking cases where the best binary candidate did not match the desired full path or have the exact desired file name.

The issue is simple, ``std::path::Path::extension()`` extracts the file extension without a leading `.`, whereas ``std::env::consts::EXE_SUFFIX`` will include a leading dot. We were attempting to compare these two values to check if a file had an appropriate executable suffix.

The fix for this issue is to use the similar ``std::env::consts::EXE_EXTENSION`` which does not contain a leader `.`, but should provide the same expected behavior as the former.

### Reproduction

```toml
[tools]
moonwave-extractor = "evaera/moonwave@1.1.3"
```

Run ``rokit install``,
-> This should result in an error `missing binary 'moonwave' in zip file 'moonwave-extractor-v.1.1.3-win64'`

This error occurs because of the issue mentioned above, and is subsequently fixed with the changes in this PR.