### PR TITLE
Support bare executable artifacts

### DIFF
--- a/lib/sources/artifact/format.rs
+++ b/lib/sources/artifact/format.rs
@@ -10,6 +10,8 @@ pub enum ArtifactFormat {
     Zip,
     Tar,
     TarGz,
+    Pe,
+    Elf,
 }
 
 impl ArtifactFormat {
@@ -19,6 +21,8 @@ impl ArtifactFormat {
             Self::Zip => "zip",
             Self::Tar => "tar",
             Self::TarGz => "tar.gz",
+            Self::Pe => "exe",
+            Self::Elf => "",
         }
     }
 
@@ -33,6 +37,8 @@ impl ArtifactFormat {
             {
                 Some(Self::TarGz)
             }
+            [.., ext] if ext.eq_ignore_ascii_case("exe") => Some(Self::Pe),
+            [] => Some(Self::Elf),
             _ => None,
         }
     }
@@ -53,6 +59,8 @@ impl FromStr for ArtifactFormat {
             "zip" => Ok(Self::Zip),
             "tar" => Ok(Self::Tar),
             "tar.gz" | "tgz" => Ok(Self::TarGz),
+            "exe" => Ok(Self::Pe),
+            "bin" => Ok(Self::Elf),
             _ => Err(format!("unknown artifact format '{l}'")),
         }
     }

--- a/lib/sources/artifact/format.rs
+++ b/lib/sources/artifact/format.rs
@@ -38,7 +38,7 @@ impl ArtifactFormat {
                 Some(Self::TarGz)
             }
             [.., ext] if ext.eq_ignore_ascii_case("exe") => Some(Self::Pe),
-            [] => Some(Self::Elf),
+            [""] => Some(Self::Elf),
             _ => None,
         }
     }
@@ -102,8 +102,8 @@ mod tests {
 
     #[test]
     fn format_from_extensions_invalid() {
-        assert_eq!(format_from_str("file-name"), None);
-        assert_eq!(format_from_str("some/file.exe"), None);
+        assert_eq!(format_from_str("file-name.txt"), None);
+        assert_eq!(format_from_str("some/file.mp4"), None);
         assert_eq!(format_from_str("really.long.file.name"), None);
     }
 
@@ -125,6 +125,14 @@ mod tests {
             format_from_str("sentry-cli-linux-i686-2.32.1.tgz"),
             Some(ArtifactFormat::TarGz)
         );
+        assert_eq!(
+            format_from_str("sentry-cli-Linux-x86_64"),
+            Some(ArtifactFormat::Elf)
+        );
+        assert_eq!(
+            format_from_str("sentry-cli-Windows-x86_64.exe"),
+            Some(ArtifactFormat::Pe)
+        );
     }
 
     #[test]
@@ -138,5 +146,8 @@ mod tests {
         assert_eq!(format_from_str("file.tar.gz"), Some(ArtifactFormat::TarGz));
         assert_eq!(format_from_str("file.TAR.GZ"), Some(ArtifactFormat::TarGz));
         assert_eq!(format_from_str("file.Tar.Gz"), Some(ArtifactFormat::TarGz));
+        assert_eq!(format_from_str("file.exe"), Some(ArtifactFormat::Pe));
+        assert_eq!(format_from_str("file.EXE"), Some(ArtifactFormat::Pe));
+        assert_eq!(format_from_str("file"), Some(ArtifactFormat::Elf));
     }
 }

--- a/lib/sources/artifact/mod.rs
+++ b/lib/sources/artifact/mod.rs
@@ -74,6 +74,7 @@ impl Artifact {
                 let tar = decompress_gzip(&contents).await?;
                 extract_tar_file(&tar, &file_name).await
             }
+            ArtifactFormat::Pe | ArtifactFormat::Elf => Ok(Some(contents.clone())),
         };
 
         // Make sure we got back the file we need ...

--- a/lib/sources/artifact/sorting.rs
+++ b/lib/sources/artifact/sorting.rs
@@ -161,6 +161,8 @@ mod tests {
         test_some_mentions("selene-light-0.27.1-linux.zip", "selene");
         // Valid - but multiple words
         test_no_mentions("sentry-cli-linux-i686-2.32.1", "sentry-cli");
+        test_no_mentions("sentry-cli-Windows-i686.exe", "sentry-cli");
+        test_no_mentions("sentry-cli-Linux-i686", "sentry-cli");
         test_no_mentions("selene-light-0.27.1-linux.zip", "selene-light");
     }
 }

--- a/lib/sources/artifact/util.rs
+++ b/lib/sources/artifact/util.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-const ALLOWED_EXTENSION_NAMES: [&str; 4] = ["zip", "tar", "gz", "tgz"];
+const ALLOWED_EXTENSION_NAMES: [&str; 6] = ["zip", "tar", "gz", "tgz", "exe", ""];
 const ALLOWED_EXTENSION_COUNT: usize = 2;
 
 pub(super) fn split_filename_and_extensions(name: &str) -> (&str, Vec<&str>) {

--- a/lib/sources/artifact/util.rs
+++ b/lib/sources/artifact/util.rs
@@ -9,23 +9,34 @@ pub(super) fn split_filename_and_extensions(name: &str) -> (&str, Vec<&str>) {
 
     // Reverse-pop extensions off the path until we reach the
     // base name - we will then need to reverse afterwards, too
-    while let Some(ext) = path.extension() {
-        let ext = ext.to_str().expect("input was str");
-        let stem = path.file_stem().expect("had an extension");
+    loop {
+        if let Some(ext) = path.extension() {
+            let ext = ext.to_str().expect("input was str");
+            println!("Ext: {ext}");
+            let stem = path.file_stem().expect("had an extension");
 
-        if !ALLOWED_EXTENSION_NAMES
-            .iter()
-            .any(|e| e.eq_ignore_ascii_case(ext))
-        {
+            if !ALLOWED_EXTENSION_NAMES
+                .iter()
+                .any(|e| e.eq_ignore_ascii_case(ext))
+            {
+                break;
+            }
+
+            exts.push(ext);
+            path = Path::new(stem);
+
+            if exts.len() >= ALLOWED_EXTENSION_COUNT {
+                break;
+            }
+        } else {
+            // Push an empty string if there are no more extensions in the path
+            exts.push("");
             break;
         }
+    }
 
-        exts.push(ext);
-        path = Path::new(stem);
-
-        if exts.len() >= ALLOWED_EXTENSION_COUNT {
-            break;
-        }
+    if exts.len() > 1 && exts.contains(&"") {
+        exts.pop();
     }
 
     exts.reverse();


### PR DESCRIPTION
Closes #7.

Would be nice to have some examples of tools other than sentry that also include bare executable releases for tests.