### PR TITLE
Set a more descriptive user agent

### DIFF
--- a/lib/sources/client.rs
+++ b/lib/sources/client.rs
@@ -1,6 +1,10 @@
 use std::time::Duration;
 
-use reqwest::{header::HeaderMap, Client, Error};
+use reqwest::{
+    header::{HeaderMap, USER_AGENT},
+    Client, Error,
+};
+
 use reqwest_middleware::{ClientBuilder, ClientWithMiddleware};
 use reqwest_retry::{policies::ExponentialBackoff, RetryTransientMiddleware};
 use reqwest_tracing::TracingMiddleware;
@@ -26,8 +30,18 @@ fn add_client_middleware(client: Client) -> ClientWithMiddleware {
     - HTTPS only
     - Timeouts for connection and response
     - All common compression algorithms enabled
+    - User agent set to `<crate_name>/<crate_version> (<repository_url>)`
 */
-pub fn create_client(default_headers: HeaderMap) -> Result<ClientWithMiddleware, Error> {
+pub fn create_client(mut default_headers: HeaderMap) -> Result<ClientWithMiddleware, Error> {
+    let user_agent = format!(
+        "{}/{} ({})",
+        env!("CARGO_PKG_NAME"),
+        env!("CARGO_PKG_VERSION"),
+        env!("CARGO_PKG_REPOSITORY"),
+    );
+
+    default_headers.insert(USER_AGENT, user_agent.parse().unwrap());
+
     let client = Client::builder()
         .default_headers(default_headers)
         .https_only(true)
@@ -37,5 +51,6 @@ pub fn create_client(default_headers: HeaderMap) -> Result<ClientWithMiddleware,
         .brotli(true)
         .deflate(true)
         .build()?;
+
     Ok(add_client_middleware(client))
 }

--- a/lib/sources/github/mod.rs
+++ b/lib/sources/github/mod.rs
@@ -4,7 +4,7 @@ use serde::de::DeserializeOwned;
 use tracing::{debug, instrument};
 
 use reqwest::{
-    header::{HeaderMap, HeaderName, HeaderValue, ACCEPT, AUTHORIZATION, USER_AGENT},
+    header::{HeaderMap, HeaderName, HeaderValue, ACCEPT, AUTHORIZATION},
     StatusCode,
 };
 
@@ -32,7 +32,6 @@ impl GithubProvider {
         let has_auth = pat.is_some();
         let headers = {
             let mut headers = HeaderMap::new();
-            headers.insert(USER_AGENT, HeaderValue::from_static("rokit"));
             headers.insert(
                 HeaderName::from_static("x-github-api-version"),
                 HeaderValue::from_static("2022-11-28"),


### PR DESCRIPTION
This PR changes the `User-Agent` in the GitHub client and any future client(s) to be more descriptive.

Users have been encountering `403 Forbidden` errors when using Rokit, and a potential cause is GitHub not allowing requests from nondescript user agents and that are not authorized somehow. Hopefully this change improves that.