### PR TITLE
Added support for artifacts compressed as '.gz' 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Added support for artifacts compressed as '.gz' ([#73])
+
+[#73]: https://github.com/rojo-rbx/rokit/pull/73
+
 ### Changed
 
 - Changed instructions in `self-install` command on Windows to tell the user to restart their _computer_ instead of their _terminal_ ([#71])

--- a/lib/sources/artifact/format.rs
+++ b/lib/sources/artifact/format.rs
@@ -10,6 +10,7 @@ pub enum ArtifactFormat {
     Zip,
     Tar,
     TarGz,
+    Gz,
 }
 
 impl ArtifactFormat {
@@ -19,6 +20,7 @@ impl ArtifactFormat {
             Self::Zip => "zip",
             Self::Tar => "tar",
             Self::TarGz => "tar.gz",
+            Self::Gz => "gz",
         }
     }
 
@@ -33,6 +35,7 @@ impl ArtifactFormat {
             {
                 Some(Self::TarGz)
             }
+            [.., ext] if ext.eq_ignore_ascii_case("gz") => Some(Self::Gz),
             _ => None,
         }
     }
@@ -78,6 +81,8 @@ mod tests {
         assert_eq!(format_from_str("file.zip"), Some(ArtifactFormat::Zip));
         assert_eq!(format_from_str("file.tar"), Some(ArtifactFormat::Tar));
         assert_eq!(format_from_str("file.tar.gz"), Some(ArtifactFormat::TarGz));
+        assert_eq!(format_from_str("file.tgz"), Some(ArtifactFormat::TarGz));
+        assert_eq!(format_from_str("file.gz"), Some(ArtifactFormat::Gz));
         assert_eq!(
             format_from_str("file.with.many.extensions.tar.gz.zip"),
             Some(ArtifactFormat::Zip)
@@ -117,6 +122,10 @@ mod tests {
             format_from_str("sentry-cli-linux-i686-2.32.1.tgz"),
             Some(ArtifactFormat::TarGz)
         );
+        assert_eq!(
+            format_from_str("lefthook_1.7.14_Windows_x86_64.gz"),
+            Some(ArtifactFormat::Gz)
+        );
     }
 
     #[test]
@@ -130,5 +139,11 @@ mod tests {
         assert_eq!(format_from_str("file.tar.gz"), Some(ArtifactFormat::TarGz));
         assert_eq!(format_from_str("file.TAR.GZ"), Some(ArtifactFormat::TarGz));
         assert_eq!(format_from_str("file.Tar.Gz"), Some(ArtifactFormat::TarGz));
+        assert_eq!(format_from_str("file.tgz"), Some(ArtifactFormat::TarGz));
+        assert_eq!(format_from_str("file.TGZ"), Some(ArtifactFormat::TarGz));
+        assert_eq!(format_from_str("file.Tgz"), Some(ArtifactFormat::TarGz));
+        assert_eq!(format_from_str("file.gz"), Some(ArtifactFormat::Gz));
+        assert_eq!(format_from_str("file.GZ"), Some(ArtifactFormat::Gz));
+        assert_eq!(format_from_str("file.Gz"), Some(ArtifactFormat::Gz));
     }
 }

--- a/lib/sources/artifact/mod.rs
+++ b/lib/sources/artifact/mod.rs
@@ -84,6 +84,7 @@ impl Artifact {
                 let tar = decompress_gzip(&contents).await?;
                 extract_tar_file(&tar, &file_name).await
             }
+            ArtifactFormat::Gz => decompress_gzip(&contents).await.map(Some),
         };
 
         // Make sure we got back the file we need ...


### PR DESCRIPTION
Some repos compress artifacts to .gz files, which this PR adds support for:

https://github.com/evilmartians/lefthook/releases

```batch
> rokit add evilmartians/lefthook
🚀 Added version 1.7.14 of tool lefthook (took 250.96ms)
> where lefthook
C:\Users\user\.rokit\bin\lefthook.exe
> lefthook version
1.7.14
``` 

closes: #72 