### PR TITLE
Fix check for Rokit binaries under PATH

### DIFF
--- a/lib/system/env/mod.rs
+++ b/lib/system/env/mod.rs
@@ -41,7 +41,7 @@ pub async fn add_to_path(home: &Home) -> RokitResult<bool> {
 */
 #[must_use]
 pub fn exists_in_path(_home: &Home) -> bool {
-    let pattern = format!("rokit{MAIN_SEPARATOR_STR}bin");
+    let pattern = format!(".rokit{MAIN_SEPARATOR_STR}bin");
     var_os("PATH").map_or(false, |path| {
         split_paths(&path).any(|item| item.ends_with(&pattern))
     })


### PR DESCRIPTION
[Path::ends_with](https://doc.rust-lang.org/std/path/struct.Path.html#method.ends_with) checks the whole of each path component for a match rather than a substring, which leads to Rokit incorrectly reporting that it is not in `PATH`.