### PR TITLE
⭐ Add Windows equivalent install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,16 @@ curl -sSf https://raw.githubusercontent.com/rojo-rbx/rokit/main/scripts/install.
 
 ### Windows
 
+#### Option 1
+
+Run the automated installer script in PowerShell:
+
+```sh
+Invoke-RestMethod https://raw.githubusercontent.com/rojo-rbx/rokit/main/scripts/install.ps1 | Invoke-Expression
+```
+
+#### Option 2
+
 Download and run<sup>\*</sup> `rokit.exe` from the [latest release][latest-release] page - this will automatically install Rokit.
 
 <sup>\* Make sure to run `rokit.exe` **directly**, by double-clicking it in the File Explorer, for automatic installation to be triggered. <br/> If you would like to install Rokit from a terminal or shell such as PowerShell / CMD, run `rokit.exe self-install` instead.

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -16,7 +16,6 @@ Function Get-ReleaseInfo {
 	}
     
 	if ($env:GITHUB_PAT) {
-		Write-Host "NOTE: Using provided GITHUB_PAT for authentication"
 		$headers['Authorization'] = "token $env:GITHUB_PAT"
 	}
     
@@ -30,6 +29,10 @@ Function Get-ReleaseInfo {
 }
 
 try {
+	if ($env:GITHUB_PAT) {
+		Write-Host "NOTE: Using provided GITHUB_PAT for authentication"
+	}
+ 
 	Write-Host "`n[1 / 3] Looking for latest $PROGRAM_NAME release"
     
 	$apiUrl = "https://api.github.com/repos/$REPOSITORY/releases/latest"

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,109 @@
+Set-Location "$env:temp"
+
+$LatestReleaseUri = "https://github.com/rojo-rbx/rokit/releases/latest/"
+
+# Function to get the (redirected) versioned URL from the latest release endpoint
+# Courtesy of https://www.reddit.com/r/PowerShell/comments/5d516e/comment/da20wf0/
+Function Get-RedirectedUrl {
+	Param (
+		[Parameter(Mandatory = $true)]
+		[String]$Uri
+	)
+
+	try {
+		$request = [System.Net.WebRequest]::Create($Uri)
+		$request.AllowAutoRedirect = $false
+		$response = $request.GetResponse()
+
+		If (($response.StatusCode -eq "Found") -or ($response.StatusCode -eq "MovedPermanently")) {
+			$RedirectUrl = $response.GetResponseHeader("Location")
+		}
+
+		$response.Close()
+		if ($RedirectUrl) { return(Write-Output $RedirectUrl) }
+		Else { 
+			Write-Error "No redirect URL found at $Uri"
+			return $null
+		}
+	}
+	catch {
+		Write-Error "Failed to get redirected URL: $_"
+		return $null
+	}
+}
+
+try {
+	Write-Host "Detecting latest version..." -ForegroundColor Cyan
+	$LatestTaggedReleaseUri = Get-RedirectedUrl -Uri $LatestReleaseUri
+    
+	if (-not $LatestTaggedReleaseUri) {
+		throw "Failed to detect latest version. Could not get redirect from $LatestReleaseUri"
+	}
+
+	# Extract version tag from the redirect URL (preserving the v prefix for download URL)
+	$VersionTagMatch = $LatestTaggedReleaseUri | Select-String -Pattern '\/tag\/(v?.+)$'
+	if (-not $VersionTagMatch.Matches) {
+		throw "Could not parse version tag from URL: $LatestTaggedReleaseUri"
+	}
+    
+	$VersionTag = $VersionTagMatch.Matches.Groups[1].Value
+	$NumericVersion = $VersionTag -replace '^v', ''
+
+	Write-Host "Latest version detected: $NumericVersion (tag: $VersionTag)" -ForegroundColor Green
+
+	# Construct the download URL - keep the v prefix if it exists in the tag
+	$DownloadUrl = "https://github.com/rojo-rbx/rokit/releases/download/$VersionTag/rokit-$NumericVersion-windows-x86_64.zip"
+	Write-Host "Downloading from: $DownloadUrl" -ForegroundColor Cyan
+
+	# Grab the latest release asset
+	try {
+		Invoke-WebRequest $DownloadUrl -OutFile rokit.zip -ErrorAction Stop
+		Write-Host "Download successful" -ForegroundColor Green
+	}
+	catch {
+		throw "Failed to download from $DownloadUrl`: $_"
+	}
+
+	# Extract the archive
+	try {
+		Expand-Archive -Path rokit.zip -Force -ErrorAction Stop
+		Write-Host "Extraction successful" -ForegroundColor Green
+	}
+	catch {
+		throw "Failed to extract rokit.zip: $_"
+	}
+
+	# Run self-install
+	try {
+		if (Test-Path ".\rokit\rokit.exe") {
+			Write-Host "Installing rokit..." -ForegroundColor Cyan
+			Start-Process -FilePath ".\rokit\rokit.exe" -ArgumentList "self-install" -Wait -NoNewWindow
+			Write-Host "Installation successful" -ForegroundColor Green
+		}
+		else {
+			throw "rokit.exe not found in the extracted directory"
+		}
+	}
+	catch {
+		throw "Failed to run self-install: $_"
+	}
+
+	# Prevent "rokit.exe" is in use error
+	Start-Sleep -Seconds 1
+
+	# Cleanup
+	try {
+		Remove-Item rokit.zip -ErrorAction SilentlyContinue
+		Remove-Item -Recurse -Path .\rokit -ErrorAction SilentlyContinue
+		Write-Host "Cleanup completed" -ForegroundColor Green
+	}
+	catch {
+		Write-Warning "Cleanup failed: $_"
+	}
+
+	Write-Host "Rokit installation completed successfully!" -ForegroundColor Green
+}
+catch {
+	Write-Error "Installation failed: $_"
+	exit 1
+}


### PR DESCRIPTION
I'm a fan of finding ways to make installation of tools easier on Windows (choco-style). Added the option to run an install command in PowerShell identical to the linux install command and added instructions to the README. Tested on Windows 10 & Windows 11.

In the future, I'd love to be able to install rokit via [Chocolatey](https://docs.chocolatey.org/en-us/create/create-packages/): `choco install rokit`