### PR TITLE
Improved artifact executable detection

### DIFF
--- a/lib/descriptor/arch.rs
+++ b/lib/descriptor/arch.rs
@@ -47,13 +47,13 @@ impl Arch {
         Get the architecture of the current host system.
     */
     #[must_use]
-    pub fn current_system() -> Self {
-        match CURRENT_ARCH {
-            "aarch64" => Self::Arm64,
-            "x86_64" => Self::X64,
-            "x86" => Self::X86,
-            "arm" => Self::Arm32,
-            _ => panic!("Unsupported architecture: {CURRENT_ARCH}"),
+    pub const fn current_system() -> Self {
+        match CURRENT_ARCH.as_bytes() {
+            b"aarch64" => Self::Arm64,
+            b"x86_64" => Self::X64,
+            b"x86" => Self::X86,
+            b"arm" => Self::Arm32,
+            _ => panic!("Unsupported architecture"),
         }
     }
 
@@ -118,7 +118,7 @@ impl Arch {
         Get the architecture as a string, such as "x64" or "arm64".
     */
     #[must_use]
-    pub fn as_str(&self) -> &'static str {
+    pub const fn as_str(&self) -> &'static str {
         match self {
             Self::Arm64 => "arm64",
             Self::X64 => "x64",

--- a/lib/descriptor/mod.rs
+++ b/lib/descriptor/mod.rs
@@ -38,7 +38,7 @@ impl Descriptor {
         Get the description for the current host system.
     */
     #[must_use]
-    pub fn current_system() -> Self {
+    pub const fn current_system() -> Self {
         Self {
             os: OS::current_system(),
             arch: Some(Arch::current_system()),
@@ -85,7 +85,7 @@ impl Descriptor {
         Get the operating system of this description.
     */
     #[must_use]
-    pub fn os(&self) -> OS {
+    pub const fn os(&self) -> OS {
         self.os
     }
 
@@ -93,7 +93,7 @@ impl Descriptor {
         Get the architecture of this description.
     */
     #[must_use]
-    pub fn arch(&self) -> Option<Arch> {
+    pub const fn arch(&self) -> Option<Arch> {
         self.arch
     }
 
@@ -101,7 +101,7 @@ impl Descriptor {
         Get the preferred toolchain of this description.
     */
     #[must_use]
-    pub fn toolchain(&self) -> Option<Toolchain> {
+    pub const fn toolchain(&self) -> Option<Toolchain> {
         self.toolchain
     }
 

--- a/lib/descriptor/os.rs
+++ b/lib/descriptor/os.rs
@@ -38,12 +38,12 @@ impl OS {
         Get the operating system of the current host system.
     */
     #[must_use]
-    pub fn current_system() -> Self {
-        match CURRENT_OS {
-            "windows" => Self::Windows,
-            "macos" => Self::MacOS,
-            "linux" => Self::Linux,
-            _ => panic!("Unsupported OS: {CURRENT_OS}"),
+    pub const fn current_system() -> Self {
+        match CURRENT_OS.as_bytes() {
+            b"windows" => Self::Windows,
+            b"macos" => Self::MacOS,
+            b"linux" => Self::Linux,
+            _ => panic!("Unsupported OS"),
         }
     }
 
@@ -93,7 +93,7 @@ impl OS {
         Get the name of the operating system as a string.
     */
     #[must_use]
-    pub fn as_str(self) -> &'static str {
+    pub const fn as_str(self) -> &'static str {
         match self {
             Self::Windows => "windows",
             Self::MacOS => "macos",

--- a/lib/descriptor/toolchain.rs
+++ b/lib/descriptor/toolchain.rs
@@ -21,7 +21,7 @@ impl Toolchain {
         Get the toolchain of the current host system.
     */
     #[must_use]
-    pub fn current_system() -> Option<Self> {
+    pub const fn current_system() -> Option<Self> {
         None // TODO: Implement detection of the host toolchain
     }
 
@@ -44,7 +44,7 @@ impl Toolchain {
         Get the name of the toolchain as a string.
     */
     #[must_use]
-    pub fn as_str(self) -> &'static str {
+    pub const fn as_str(self) -> &'static str {
         match self {
             Self::Msvc => "msvc",
             Self::Gnu => "gnu",

--- a/lib/descriptor/toolchain.rs
+++ b/lib/descriptor/toolchain.rs
@@ -22,7 +22,15 @@ impl Toolchain {
     */
     #[must_use]
     pub const fn current_system() -> Option<Self> {
-        None // TODO: Implement detection of the host toolchain
+        if cfg!(target_env = "msvc") {
+            Some(Self::Msvc)
+        } else if cfg!(target_env = "gnu") {
+            Some(Self::Gnu)
+        } else if cfg!(target_env = "musl") {
+            Some(Self::Musl)
+        } else {
+            None
+        }
     }
 
     /**


### PR DESCRIPTION
This PR modifies the extractors for both `.zip` and `.tar`/`.tar.gz` files to inspect files within the archives, and runs descriptor (executable contents) detection on them, adding an additional datapoint for hopefully extracting correct binaries from said archives.

Notably, this should fix failed extraction for a tool that:
- Has a binary name that does not exactly match the tool name
- Has no permission bits set (unix)
- Has no executable suffix in its filename (`.exe`)

A real-world scenario where such a thing would happen:
1. A tool at a GitHub repository `toolauthor/toolname` gets forked as `organization/toolauthor-toolname`
2. The tool only has `.zip` files as its release artifacts (no permission bits)
3. The tool has binaries for unix platforms (no executable suffix)