### PR TITLE
feat(lib): allow x.y versioning scheme for tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## `Unreleased`
 
+### Added
+
+- Allow `x.y` versioning scheme in the config file ([#86])
+
 ### Changed
 
 - Modified the `rokit install` command to check if Rokit is in the user's PATH after installation, and provide appropriate instructions based on the user's operating system and shell ([#92])

--- a/lib/discovery/foreman.rs
+++ b/lib/discovery/foreman.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, str::FromStr};
 use semver::Version;
 use toml_edit::{DocumentMut, InlineTable, Table};
 
-use crate::tool::{ToolAlias, ToolId, ToolSpec};
+use crate::tool::{util::to_xyz_version, ToolAlias, ToolId, ToolSpec};
 
 use super::Manifest;
 
@@ -71,7 +71,8 @@ fn parse_foreman_tool_definition(map: SpecType) -> Option<ToolSpec> {
     let version = map.get("version").and_then(|t| t.as_str()).and_then(|v| {
         // TODO: Support real version requirements instead of just exact/min versions
         let without_prefix = v.trim_start_matches('=').trim_start_matches('^');
-        without_prefix.parse::<Version>().ok()
+        let version_str = to_xyz_version(without_prefix);
+        version_str.parse::<Version>().ok()
     })?;
     // TODO: Support gitlab tool ids
     let github_tool_id = map

--- a/lib/tool/mod.rs
+++ b/lib/tool/mod.rs
@@ -1,7 +1,7 @@
 mod alias;
 mod id;
-mod spec;
-mod util;
+pub(crate) mod spec;
+pub(crate) mod util;
 
 pub use self::alias::{ToolAlias, ToolAliasParseError};
 pub use self::id::{ToolId, ToolIdParseError};

--- a/lib/tool/spec.rs
+++ b/lib/tool/spec.rs
@@ -6,7 +6,7 @@ use thiserror::Error;
 
 use crate::sources::ArtifactProvider;
 
-use super::{util::is_invalid_identifier, ToolId, ToolIdParseError};
+use super::{util::is_invalid_identifier, util::to_xyz_version, ToolId, ToolIdParseError};
 
 /**
     Error type representing the possible errors that can occur when parsing a `ToolSpec`.
@@ -97,7 +97,8 @@ impl FromStr for ToolSpec {
             return Err(ToolSpecParseError::InvalidVersion(after.to_string()));
         }
 
-        let version = match after.parse::<Version>() {
+        let version_str = to_xyz_version(after);
+        let version = match version_str.parse::<Version>() {
             Ok(version) => version,
             Err(e) => {
                 return match after.parse::<VersionReq>() {

--- a/lib/tool/spec.rs
+++ b/lib/tool/spec.rs
@@ -148,6 +148,7 @@ mod tests {
         // Basic strings should parse ok
         assert!("a/b@0.0.0".parse::<ToolSpec>().is_ok());
         assert!("author/name@1.2.3".parse::<ToolSpec>().is_ok());
+        assert!("author/name@6.9".parse::<ToolSpec>().is_ok());
         assert!("123abc456/78de90@11.22.33".parse::<ToolSpec>().is_ok());
         // The parsed ToolSpec should match the input
         assert_eq!(
@@ -157,6 +158,10 @@ mod tests {
         assert_eq!(
             "author/name@1.2.3".parse::<ToolSpec>().unwrap(),
             new_spec("author", "name", "1.2.3"),
+        );
+        assert_eq!(
+            "author/name@6.9".parse::<ToolSpec>().unwrap(),
+            new_spec("author", "name", "6.9.0"),
         );
         assert_eq!(
             "123abc456/78de90@11.22.33".parse::<ToolSpec>().unwrap(),

--- a/lib/tool/util.rs
+++ b/lib/tool/util.rs
@@ -1,3 +1,21 @@
+use std::borrow::Cow;
+
+pub(crate) fn to_xyz_version(v_str: &str) -> Cow<str> {
+    let (version_num_part, rest) = v_str
+        .find(['-', '+'])
+        .map(|i| v_str.split_at(i))
+        .unwrap_or((v_str, ""));
+
+    let num_dots = version_num_part.matches('.').count();
+
+    if num_dots == 1 {
+        // x.y
+        return Cow::Owned(format!("{}.0{}", version_num_part, rest));
+    }
+
+    Cow::Borrowed(v_str)
+}
+
 pub fn is_invalid_identifier(s: &str) -> bool {
     s.is_empty() // Must not be empty
         || s.chars().all(char::is_whitespace) // Must contain some information

--- a/lib/tool/util.rs
+++ b/lib/tool/util.rs
@@ -1,16 +1,15 @@
 use std::borrow::Cow;
 
-pub(crate) fn to_xyz_version(v_str: &str) -> Cow<str> {
+pub(crate) fn to_xyz_version(v_str: &str) -> Cow<'_, str> {
     let (version_num_part, rest) = v_str
         .find(['-', '+'])
-        .map(|i| v_str.split_at(i))
-        .unwrap_or((v_str, ""));
+        .map_or((v_str, ""), |i| v_str.split_at(i));
 
     let num_dots = version_num_part.matches('.').count();
 
     if num_dots == 1 {
         // x.y
-        return Cow::Owned(format!("{}.0{}", version_num_part, rest));
+        return Cow::Owned(format!("{version_num_part}.0{rest}"));
     }
 
     Cow::Borrowed(v_str)


### PR DESCRIPTION
Previously, Rokit strictly required tool versions to follow the `x.y.z` semantic versioning scheme. This would cause parsing errors when a tool in a manifest or a release on GitHub used a simpler `x.y` version, such as `luau@0.683`.

This change introduces support for the `x.y` versioning scheme by transparently converting such versions to a compatible `x.y.0` format before they are processed by the `semver` library.

This includes:
- A new utility function to convert `x.y` version strings to `x.y.0`, correctly handling pre-release tags and build metadata.
- Integration of this utility into the parsing logic for `rokit.toml`, `foreman.toml`, and GitHub release tags.
- Enhanced the GitHub release fetching logic to first check for the exact tag (e.g., `v1.2.0`) and then fall back to the `x.y` version (e.g., `v1.2`) if the initial tag is not found. This improves compatibility with repositories that use a two-digit versioning scheme for their releases.

Solves #86 